### PR TITLE
Re-Work of Export Code

### DIFF
--- a/core/google.py
+++ b/core/google.py
@@ -190,6 +190,22 @@ class SearchResult:
     def __str__(self):
         return str(self.to_dict())
 
+    @staticmethod
+    def from_dict(dictionary):
+        """
+        Create a SearchResult from a dictionary.
+
+        This factory method is the inverse of the SearchResult.to_dict
+
+        :param dictionary: The dictionary (such as one obtained from SearchResult.to_dict)
+        :return: The SearchResult instance
+        :raises: KeyError if the dictionary does not contain a required key
+        """
+        url = dictionary[SearchResult.URL]
+        title = dictionary[SearchResult.TITLE]
+        content = dictionary[SearchResult.CONTENT]
+        return SearchResult(url, title, content)
+
 
 class Sifter:
     """

--- a/pivoteer/forms.py
+++ b/pivoteer/forms.py
@@ -5,6 +5,7 @@ from .models import TaskTracker
 from .tasks import *
 
 from celery import group
+from pivoteer.records import RecordSource, RecordType
 
 
 class SubmissionForm(forms.Form):
@@ -68,16 +69,16 @@ class SubmissionForm(forms.Form):
 
         elif record_type == "Historical":
             if self.indicator_type != "other":
-                new_task = group([passive_hosts.s(indicator, "VTO"),
-                                  # passive_hosts.s(indicator, "PTO"),
-                                  passive_hosts.s(indicator, "IID")])()
+                new_task = group([passive_hosts.s(indicator, RecordSource.VTO),
+                                  # passive_hosts.s(indicator, RecordSource.PTO),
+                                  passive_hosts.s(indicator, RecordSource.IID)])()
             else:
                 new_task = None
 
         elif record_type == "Malware":
             if self.indicator_type != "other":
-                new_task = group([malware_samples.s(indicator, "TEX"),
-                                  malware_samples.s(indicator, "VTO"),
+                new_task = group([malware_samples.s(indicator, RecordSource.TEX),
+                                  malware_samples.s(indicator, RecordSource.VTO),
                                   totalhash_ip_domain_search.s(indicator)])()
             else:
                 new_task = None

--- a/pivoteer/models.py
+++ b/pivoteer/models.py
@@ -151,7 +151,11 @@ class IndicatorManager(models.Manager):
 
             if hash_value not in tracking:
                 record_info = self.get_queryset().filter(info_hash=hash_value).values('info')[0]['info']
-                new_record = {'latest': record['latest'], 'earliest': record['earliest'], 'info': record_info}
+                span = str(record['earliest']) + " / " + str(record['latest'])
+                new_record = {'latest': record['latest'],
+                              'earliest': record['earliest'],
+                              'info_date': span,
+                              'info': record_info}
                 unique_records.append(new_record)
                 tracking.append(hash_value)
 

--- a/pivoteer/records.py
+++ b/pivoteer/records.py
@@ -1,0 +1,76 @@
+"""
+Functions, classes, and enumerations particular to our indicator record types and sources
+
+The RecordType enumeration defines the IndicatorRecord types supported in Pivoteer.  To add a new record, you will need
+to give it a two-character name (enumeration constant) as well as a more descriptive title.  You should ALWAYS use
+RecordType enumerations rather than using a "magic string" for the type.
+
+The RecordSource enumeration is very similar to the RecordType enumeration.  Whereas RecordType specifies the type of a
+record, RecordSource tells where that record came from.  Multiple record sources may possible create the records of the
+same type, and a record source might also theoretically produce records of multiple types.  As with RecordType, new
+record sources require a three-character name as well as a human-readable title.
+"""
+
+try:
+    # Python 3
+    import enum
+except ImportError:
+    # Python 2
+    import enum34 as enum
+
+
+class __TitledEnum(enum.Enum):
+    """
+    A base class for enumerations which are defined by a string value also accessible via the 'title' property
+    """
+
+    def __init__(self, title):
+        """
+        Create a new enumerated value with the given title
+        :param title: The title
+        """
+        self.__title = title
+
+    @property
+    def title(self):
+        """
+        Get the title of this enumerated value.
+
+        This method will also provide "title" as a read-only property of instance of instances of this class.
+
+        :return: The title
+        """
+        return self.__title
+
+
+@enum.unique
+class RecordType(__TitledEnum):
+    """
+    A titled enumeration of record types
+    """
+    CE = "Censys Record"
+    HR = "Host Record"
+    MR = "Malware Record"
+    SB = "SafeBrowsing Record"
+    SR = "Search Record"
+    TR = "ThreatCrowd Record"
+    WR = "Whois Record"
+
+
+@enum.unique
+class RecordSource(__TitledEnum):
+    """
+    A titled enumeration of sources for indicator records
+    """
+    CEN = "Censys.io"
+    DNS = "DNS Query"
+    GSB = "Google Safe Browsing"
+    GSE = "Google Search Engine"
+    IID = "Internet Identity"
+    PTO = "Passive Total"
+    REX = "Robotex"
+    TEX = "Threat Expert"
+    THR = "ThreatCrowd"
+    THS = "Total Hash"
+    VTO = "Virus Total"
+    WIS = "WHOIS"

--- a/pivoteer/tasks.py
+++ b/pivoteer/tasks.py
@@ -13,169 +13,220 @@ from core.lookups import lookup_ip_whois, lookup_domain_whois, resolve_domain, g
 from pivoteer.collectors.scrape import RobtexScraper, InternetIdentityScraper
 from pivoteer.collectors.scrape import VirusTotalScraper, ThreatExpertScraper
 from pivoteer.collectors.api import PassiveTotal
+from pivoteer.records import RecordSource, RecordType
 from .models import IndicatorRecord
 
 logger = logging.getLogger(None)
 
 
-@app.task(bind=True)
-def certificate_cen(self, indicator):
-    current_time = datetime.datetime.utcnow()
+def create_record(record_type,
+                  record_source,
+                  info,
+                  date=None):
+    """
+    Create an indicator record.
+
+    :param record_type: The record type, which should be a value from the RecordType enumeration
+    :param record_source: The source for the record, which should be a value from the RecordSource enumeration
+    :param info: The actual data to be stored in the record
+    :param date: The date to use with this record, or None to use the current date
+    :return: The new IndicatorRecord instance
+    """
+    current_time = date or datetime.datetime.utcnow()
+    record = IndicatorRecord(record_type=record_type.name,
+                             info_source=record_source.name,
+                             info_date=current_time,
+                             info=info)
+    logger.info("Created %s (%s) record from %s: %s",
+                record_type.name,
+                record_type.title,
+                record_source.title,
+                record)
+    return record
+
+
+def save_record(record_type,
+                record_source,
+                info,
+                date=None):
+    """
+    A convenience function that calls 'create_record' and also saves the resulting record.
+
+    :param record_type: The record type, which should be a value from the RecordType enumeration
+    :param record_source: The source for the record, which should be a value from the RecordSource enumeration
+    :param info: The actual data to be stored in the record
+    :param date: The date to use with this record, or None to use the current date
+    :return: The new IndicatorRecord instance
+    """
+    record = create_record(record_type, record_source, info, date)
+    record.save()
+    logger.info("%s (%s) record from %s saved successfully",
+                record_type.name,
+                record_type.title,
+                record_source.title)
+    return record
+
+
+@app.task
+def certificate_cen(indicator):
+    record_type = RecordType.CE
+    record_source = RecordSource.CEN
     record = lookup_certs_censys(indicator, 25)
     record['indicator'] = indicator
     logger.info("Retrieved Censys.io search results for indicator %s" % indicator)
     if record:
         try:
-            record_entry = IndicatorRecord(record_type="CE",
-                                           info_source="CEN",
-                                           info_date=current_time,
-                                           info=record)
-            record_entry.save()
-            logger.info("CE record saved successfully")
-        except Exception as e:
-            logger.warn("Error creating or saving CE record: %s" % str(e))
+            save_record(record_type, record_source, record)
+        except Exception:
+            logger.exception("Error saving %s (%s) record from %s",
+                             record_type.name,
+                             record_type.title,
+                             record_source.title)
 
 
 # Task to look up threatcrowd domain
-@app.task(bind=True)
-def domain_thc(self, domain):
-    current_time = datetime.datetime.utcnow()
+@app.task
+def domain_thc(domain):
+    record_type = RecordType.TR
+    record_source = RecordSource.THR
     record = ThreatCrowd.queryDomain(domain)
     record['domain'] = domain
     logger.info("Retrieved ThreatCrowd data for domain %s. Data: %s" % (domain, json.dumps(record)))
     if record:
         try:
-            record_entry = IndicatorRecord(record_type="TR",
-                                           info_source="THR",
-                                           info_date=current_time,
-                                           info=record)
-            logger.info("Created TR record_entry %s" % str(record_entry))
-            record_entry.save()
-            logger.info("TR record saved successfully")
-        except Exception as e:
-            logger.warn("Error creating or saving TR record: %s" % str(e))
-            print(e)
+            save_record(record_type, record_source, record)
+        except Exception:
+            logger.exception("Error saving %s (%s) record from %s",
+                             record_type.name,
+                             record_type.title,
+                             record_source.title)
 
 
 # Task to look up threatcrowd ip
-@app.task(bind=True)
-def ip_thc(self, ip):
-    current_time = datetime.datetime.utcnow()
+@app.task
+def ip_thc(ip):
+    record_type = RecordType.TR
+    record_source = RecordSource.THR
     record = ThreatCrowd.queryIp(ip)
     record['ip'] = ip
     if record:
         try:
-            record_entry = IndicatorRecord(record_type="TR",
-                                           info_source="THR",
-                                           info_date=current_time,
-                                           info=record)
-            record_entry.save()
-        except Exception as e:
-            print(e)
+            save_record(record_type, record_source, record)
+        except Exception:
+            logger.exception("Error saving %s (%s) record from %s",
+                             record_type.name,
+                             record_type.title,
+                             record_source.title)
 
 
-@app.task(bind=True)
-def domain_whois(self, domain):
-    current_time = datetime.datetime.utcnow()
+@app.task
+def domain_whois(domain):
+    record_type = RecordType.WR
+    record_source = RecordSource.WIS
     record = lookup_domain_whois(domain)
 
     if record:
         try:
-            record_entry = IndicatorRecord(record_type="WR",
-                                           info_source="WIS",
-                                           info_date=current_time,
-                                           info=OrderedDict({'domain_name': record['domain_name'],
-                                                             'status': record['status'],
-                                                             'registrar': record['registrar'],
-                                                             'updated_date': record['updated_date'],
-                                                             'expiration_date': record['expiration_date'],
-                                                             'nameservers': record['nameservers'],
-                                                             'contacts': record['contacts']}))
-            record_entry.save()
-        except Exception as e:
-            print(e)
+            info = OrderedDict({'domain_name': record['domain_name'],
+                                'status': record['status'],
+                                'registrar': record['registrar'],
+                                'updated_date': record['updated_date'],
+                                'expiration_date': record['expiration_date'],
+                                'nameservers': record['nameservers'],
+                                'contacts': record['contacts']})
+            save_record(record_type, record_source, info)
+        except Exception:
+            logger.exception("Error saving %s (%s) record from %s",
+                             record_type.name,
+                             record_type.title,
+                             record_source.title)
 
 
-@app.task(bind=True)
-def ip_whois(self, ip_address):
-    current_time = datetime.datetime.utcnow()
+@app.task
+def ip_whois(ip_address):
+    record_type = RecordType.WR
+    record_source = RecordSource.WIS
     record = lookup_ip_whois(ip_address)
 
     if record:
         try:
-            record_entry = IndicatorRecord(record_type="WR",
-                                           info_source="WIS",
-                                           info_date=current_time,
-                                           info=OrderedDict({'query': record['query'],
-                                                             'asn_cidr': record['asn_cidr'],
-                                                             'asn': record['asn'],
-                                                             'asn_registry': record['asn_registry'],
-                                                             'asn_country_code': record['asn_country_code'],
-                                                             'asn_date': record['asn_date'],
-                                                             'referral': record['referral'],
-                                                             'nets': record['nets']}))
-            record_entry.save()
-        except Exception as e:
-            print(e)
+            info = OrderedDict({'query': record['query'],
+                                'asn_cidr': record['asn_cidr'],
+                                'asn': record['asn'],
+                                'asn_registry': record['asn_registry'],
+                                'asn_country_code': record['asn_country_code'],
+                                'asn_date': record['asn_date'],
+                                'referral': record['referral'],
+                                'nets': record['nets']})
+            save_record(record_type, record_source, info)
+        except Exception:
+            logger.exception("Error saving %s (%s) record from %s",
+                             record_type.name,
+                             record_type.title,
+                             record_source.title)
 
 
-@app.task(bind=True)
-def domain_hosts(self, domain):
-    current_time = datetime.datetime.utcnow()
+@app.task
+def domain_hosts(domain):
     hosts = resolve_domain(domain)
-
     if type(hosts) == list:
+        record_type = RecordType.HR
+        record_source = RecordSource.DNS
         for host in hosts:
-
             ip_location = geolocate_ip(host)
             https_cert = lookup_ip_censys_https(host)
-
+            info = OrderedDict({"geo_location": ip_location,
+                                "https_cert": https_cert,
+                                "ip": host, "domain": domain})
             try:
-                record_entry = IndicatorRecord(record_type="HR",
-                                               info_source="DNS",
-                                               info_date=current_time,
-                                               info=OrderedDict({"geo_location": ip_location,
-                                                                 "https_cert": https_cert,
-                                                                 "ip": host, "domain": domain}))
-                record_entry.save()
-            except Exception as e:
-                print(e)
+                save_record(record_type,
+                            record_source,
+                            info)
+            except Exception:
+                logger.exception("Error saving %s (%s) record from %s",
+                                 record_type.name,
+                                 record_type.title,
+                                 record_source.title)
 
 
-@app.task(bind=True)
-def ip_hosts(self, ip_address):
-    current_time = datetime.datetime.utcnow()
+@app.task
+def ip_hosts(ip_address):
     scraper = RobtexScraper()
     hosts = scraper.run(ip_address)
     ip_location = geolocate_ip(ip_address)
     https_cert = lookup_ip_censys_https(ip_address)
 
     if type(hosts) == list:
+        record_type = RecordType.HR
+        record_source = RecordSource.REX
         for host in hosts:
             try:
-                record_entry = IndicatorRecord(record_type="HR",
-                                               info_source="REX",
-                                               info_date=current_time,
-                                               info=OrderedDict({"geo_location": ip_location,
-                                                                 "https_cert": https_cert,
-                                                                 "ip": ip_address, "domain": host}))
-                record_entry.save()
-            except Exception as e:
-                print(e)
+                info = OrderedDict({"geo_location": ip_location,
+                                    "https_cert": https_cert,
+                                    "ip": ip_address, "domain": host})
+                save_record(record_type,
+                            record_source,
+                            info)
+            except Exception:
+                logger.exception("Error saving %s (%s) record from %s",
+                                 record_type.name,
+                                 record_type.title,
+                                 record_source.title)
 
 
-@app.task(bind=True)
-def passive_hosts(self, indicator, source):
-    if source == "IID":
+@app.task
+def passive_hosts(indicator, record_source):
+    record_type = RecordType.HR
+    if record_source is RecordSource.IID:
         scraper = InternetIdentityScraper()
         passive = scraper.run(indicator)  # returns table of data rows {ip, domain, date, ip_location}
 
-    elif source == "PTO":
+    elif record_source is RecordSource.PTO:
         api_key = settings.PASSIVE_TOTAL_API
         collector = PassiveTotal(api_key, api_version="v1")
         passive = collector.retrieve_data(indicator, "passive")
 
-    elif source == "VTO":
+    elif record_source is RecordSource.VTO:
         scraper = VirusTotalScraper()
         passive = scraper.get_passive(indicator)  # returns table of data rows {ip, domain, date, ip_location}
 
@@ -184,23 +235,26 @@ def passive_hosts(self, indicator, source):
 
     for entry in passive:
         try:
-            record_entry = IndicatorRecord(record_type="HR",
-                                           info_source=source,
-                                           info_date=entry['date'],
-                                           info=OrderedDict({"geo_location": entry['ip_location'],
-                                                             "ip": entry['ip'], "domain": entry['domain']}))
-            record_entry.save()
-        except Exception as e:
-            print(e)
+            date = entry['date']
+            info = OrderedDict({"geo_location": entry['ip_location'],
+                                "ip": entry['ip'],
+                                "domain": entry['domain']})
+            save_record(record_type, record_source, info, date=date)
+        except Exception:
+            logger.exception("Error saving %s (%s) record from %s",
+                             record_type.name,
+                             record_type.title,
+                             record_source.title)
 
 
-@app.task(bind=True)
-def malware_samples(self, indicator, source):
-    if source == "VTO":
+@app.task
+def malware_samples(indicator, record_source):
+    record_type = RecordType.MR
+    if record_source is RecordSource.VTO:
         scraper = VirusTotalScraper()
-        malware = scraper.get_malware(indicator)  #
+        malware = scraper.get_malware(indicator)
 
-    elif source == "TEX":
+    elif record_source is RecordSource.TEX:
         scraper = ThreatExpertScraper()
         malware = scraper.run(indicator)
 
@@ -209,41 +263,45 @@ def malware_samples(self, indicator, source):
 
     for entry in malware:
         try:
-            record_entry = IndicatorRecord(record_type="MR",
-                                           info_source=source,
-                                           info_date=entry['date'],
-                                           info=OrderedDict({"md5": entry['md5'],
-                                                             "sha1": entry['sha1'],
-                                                             "sha256": entry['sha256'],
-                                                             "indicator": entry['C2'],
-                                                             "link": entry['link']}))
-            record_entry.save()
-        except Exception as e:
-            print(e)
+            date = entry['date']
+            info = OrderedDict({"md5": entry['md5'],
+                                "sha1": entry['sha1'],
+                                "sha256": entry['sha256'],
+                                "indicator": entry['C2'],
+                                "link": entry['link']})
+            save_record(record_type, record_source, info, date=date)
+        except Exception:
+            logger.exception("Error saving %s (%s) record from %s",
+                             record_type.name,
+                             record_type.title,
+                             record_source.title)
 
 
-@app.task(bind=True)
-def google_safebrowsing(self, indicator):
-    current_time = datetime.datetime.utcnow()
+@app.task
+def google_safebrowsing(indicator):
+    record_type = RecordType.SB
+    record_source = RecordSource.GSB
     safebrowsing_response = lookup_google_safe_browsing(indicator)
     safebrowsing_status = safebrowsing_response[0]
     safebrowsing_body = safebrowsing_response[1]
+    # We store the status code that the Google SafeSearch API returns.
+    info = OrderedDict({"indicator": indicator,
+                        "statusCode": safebrowsing_status,
+                        "body": safebrowsing_body})
     try:
-        record_entry = IndicatorRecord(record_type="SB",
-                                       info_source='GSB',
-                                       info_date=current_time,
-                                       # We store the status code that the Google SafeSearch API returns.
-                                       info=OrderedDict({"indicator": indicator,
-                                                         "statusCode": safebrowsing_status,
-                                                         "body": safebrowsing_body}))
-        record_entry.save()
-    except Exception as e:
-        print(e)
+        save_record(record_type, record_source, info)
+    except Exception:
+        logger.exception("Error saving %s (%s) record from %s",
+                         record_type.name,
+                         record_type.title,
+                         record_source.title)
 
 
 # Task to look up totalhash ip or domain search terms
-@app.task(bind=True)
-def totalhash_ip_domain_search(self, indicator):
+@app.task
+def totalhash_ip_domain_search(indicator):
+    record_type = RecordType.MR
+    record_source = RecordSource.THS
     th_logger = logging.getLogger(None)
     api_id = settings.TOTAL_HASH_API_ID
     api_secret = settings.TOTAL_HASH_SECRET
@@ -269,20 +327,22 @@ def totalhash_ip_domain_search(self, indicator):
             # Otherwise, some record retrieval methods may fail.
             for entry in th.scrape_hash(raw_record, 'text'):
                 hash_link = "https://totalhash.cymru.com/analysis/?" + entry
-                record_entry = IndicatorRecord(record_type="MR",
-                                               info_source="THS",
-                                               info_date=current_time,
-                                               info=OrderedDict({"sha1": entry,
-                                                                 "indicator": indicator,
-                                                                 "link": hash_link,
-                                                                 "md5": "",
-                                                                 "sha256": ""}))
-                record_entry.save()
+                info = OrderedDict({"sha1": entry,
+                                    "indicator": indicator,
+                                    "link": hash_link,
+                                    "md5": "",
+                                    "sha256": ""})
+                save_record(record_type,
+                            record_source,
+                            info,
+                            date=current_time)
 
             logger.info("%s TH record_entries saved successfully" % record_count)
-        except Exception as e:
-            logger.warn("Error creating or saving TH record: %s" % str(e))
-            print(e)
+        except Exception:
+            logger.exception("Error saving %s (%s) record from %s",
+                             record_type.name,
+                             record_type.title,
+                             record_source.title)
     else:
         logger.info("No Totalhash data, save aborted")
 
@@ -307,15 +367,16 @@ def make_indicator_search_records(indicator, indicator_type):
     :param indicator_type: The type of the indicator
     :return: This method does not return any values
     """
+    record_type = RecordType.SR
+    record_source = RecordSource.GSE
     try:
-        current_time = datetime.datetime.utcnow()
         domain = indicator if indicator_type == 'domain' else None
         results = google_for_indicator(indicator, domain=domain)
-        record_entry = IndicatorRecord(record_type="SR",
-                                       info_source="GSE",
-                                       info_date=current_time,
-                                       info=OrderedDict({"indicator": indicator,
-                                                         "results": results}))
-        record_entry.save()
+        info = OrderedDict({"indicator": indicator,
+                            "results": results})
+        save_record(record_type, record_source, info)
     except Exception:
-        logger.exception("Error retrieving/saving Google search results for domain")
+        logger.exception("Error saving %s (%s) record from %s",
+                         record_type.name,
+                         record_type.title,
+                         record_source.title)

--- a/pivoteer/views.py
+++ b/pivoteer/views.py
@@ -3,20 +3,25 @@ import json
 import datetime
 import logging
 
-import core.google
-
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.views.generic.base import View
-from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 
 from .forms import SubmissionForm
 from .models import IndicatorRecord, TaskTracker
 from core.utilities import time_jump
-from core.lookups import geolocate_ip, resolve_domain
+from core.lookups import geolocate_ip
 from celery.result import GroupResult
 from braces.views import LoginRequiredMixin
+from pivoteer.writer.censys import CensysCsvWriter
+from pivoteer.writer.hosts import HostCsvWriter
+from pivoteer.writer.malware import MalwareCsvWriter
+from pivoteer.writer.safebrowsing import SafeBrowsingCsvWriter
+from pivoteer.writer.search import SearchCsvWriter
+from pivoteer.writer.threatcrowd import ThreatCrowdCsvWriter
+from pivoteer.writer.whois import WhoIsCsvWriter
 
 
 LOGGER = logging.getLogger(__name__)
@@ -119,15 +124,13 @@ class CheckTask(LoginRequiredMixin, View):
             # Current WHOIS record
             whois_record = IndicatorRecord.objects.recent_whois(indicator)
             self.template_vars["current_whois"] = whois_record
-            
+
             # Current ThreatCrowd record
             tc_info = IndicatorRecord.objects.recent_tc(indicator)
             self.template_vars["tc_info"] = tc_info
-            
+
             cert_info = IndicatorRecord.objects.recent_cert(indicator)
             self.template_vars["cert_info"] = cert_info
-
-
 
         elif record_type == "Historical":
 
@@ -177,6 +180,17 @@ class CheckTask(LoginRequiredMixin, View):
 
 
 class ExportRecords(LoginRequiredMixin, View):
+    # ---------------------------------------------------
+    # HELP!  I want to add export support for a new type!
+    # ---------------------------------------------------
+    # Follow these simple steps:
+    # 1. Create a pivoteer.writer.core.CsvWriter subclass that processes your record type.
+    # 2. Update ExportRecords._get_csv_writer to return an instance of the writer you created in Step 1.
+    # 3. Add a new method to ExportRecords that performs two steps:
+    #     a. Retrieve IndicatorRecords (via a method on pivoteer/models/IndicatorManager)
+    #     b. Call self._write_records with your record type, the indicator value, and the records obtained in Step A
+    #         Note: If Step A returns a single record, you must wrap it in a list for Step B
+    # 4. Update ExportRecords.get to call the method you created in Step 3.
 
     login_url = "login"
     redirect_unauthenticated_users = True
@@ -195,9 +209,13 @@ class ExportRecords(LoginRequiredMixin, View):
 
         if indicator and filtering == '':
             self.export_recent(indicator)
+            self.line_separator()
             self.export_historical(indicator, request)
+            self.line_separator()
             self.export_malware(indicator)
+            self.line_separator()
             self.export_search_records(indicator)
+            self.line_separator()
             self.export_safebrowsing_records(indicator)
 
         elif indicator and filtering == 'recent':
@@ -218,76 +236,127 @@ class ExportRecords(LoginRequiredMixin, View):
         return self.response
 
     def export_safebrowsing_records(self, indicator):
-        safebrowsing_records = IndicatorRecord.objects.safebrowsing_record(indicator)
+        """
+        Export recent 'SB' (SafeBrowsing) indicator records to CSV.
 
-        if safebrowsing_records:
-            self.line_separator()
-            self.writer.writerow(["Date", "Response", "SafeBrowsing Link"])
-            sb_link = settings.GOOGLE_SAFEBROWSING_URL + indicator
-            for record in safebrowsing_records:
-                entry = [record.info_date, record.info['body'], sb_link]
-                self.writer.writerow(entry)
+        :param indicator: The indicator whose records are to be exported
+        :return: This method returns no values
+        """
+        safebrowsing_records = IndicatorRecord.objects.safebrowsing_record(indicator)
+        self._write_records("SB", indicator, safebrowsing_records)
+
+    def export_recent_hosts(self, indicator):
+        """
+        Export recent 'HR' (Host Record) indicator records to CSV.
+
+        This method is called as part of 'export_recent.'
+
+        :param indicator: The indicator to be exported
+        :return: This method returns no values
+        """
+        hosts = IndicatorRecord.objects.recent_hosts(indicator)
+        self._write_records("HR", indicator, hosts)
+
+    def export_recent_whois(self, indicator):
+        """
+        Export recent 'WR' (Whois Record) indicator records to CSV.
+
+        This method is called as part of 'export_recent'
+
+        :param indicator: The indicator to be exported
+        :return: This method returns no values
+        """
+        whois = IndicatorRecord.objects.recent_whois(indicator)
+        self._write_records("WR", indicator, [whois])
+
+    def export_recent_threatcrowd(self, indicator):
+        """
+        Export the most recent 'TR' (ThreatCrowd Record) indicator records to CSV.
+
+        This method is called as part of 'export_recent'
+
+        :param indicator: The indicator to be exported
+        :return: This method returns no values
+        """
+        tc_info = IndicatorRecord.objects.recent_tc(indicator)
+        self._write_records("TR", indicator, [tc_info])
+
+    def export_recent_certificates(self, indicator):
+        """
+        Export recent 'CE' (Censys Record) indicator records in CSV format.
+
+        This method is called as part of 'export_recent'
+
+        :param indicator: The indicator to be exported
+        :return: This method returns no values
+        """
+        latest = IndicatorRecord.objects.recent_cert(indicator)
+        self._write_records("CE", indicator, [latest])
 
     def export_recent(self, indicator):
+        """
+        Export all data from the "Recent Activity" tab to CSV.
 
-        hosts = IndicatorRecord.objects.recent_hosts(indicator)
-        whois = IndicatorRecord.objects.recent_whois(indicator)
+        This method calls the various 'export_recent_*' methods (with a call to 'line_separator' between each) to
+        perform the actual work of exporting to CSV.
 
-        if hosts:
-            self.line_separator()
-            self.writer.writerow(["Date", "Source", "IP", "Domain", "IP Location"])
+        :param indicator: The indicator to be exported
+        :return: This method returns no values
+        """
+        self.export_recent_hosts(indicator)
+        self.line_separator()
+        self.export_recent_whois(indicator)
+        self.line_separator()
+        self.export_recent_threatcrowd(indicator)
+        self.line_separator()
+        self.export_recent_certificates(indicator)
 
-            for host in hosts:
-                entry = [host.info_date, host.info_source,
-                         host.info['ip'], host.info['domain'], host.info['geo_location']]
+    def export_historical_hosts(self, indicator, request):
+        """
+        Export historical Host Records (IndicatorRecords with record type "HR").
 
-                self.writer.writerow(entry)
+        :param indicator: The indicator whose historical records are to be exported
+        :param request: The request being processed
+        :return: This method returns no values
+        """
+        hosts = IndicatorRecord.objects.historical_hosts(indicator, request)
+        self._write_records("HR", indicator, hosts)
 
-        if whois:
-            self.line_separator()
-            self.writer.writerow(["Lookup Date", "WHOIS Information"])
-            self.writer.writerow([whois['info_date'], whois['info']])
+    def export_historical_whois(self, indicator):
+        """
+        Export historical Who Is Records (IndicatorRecords with record type "WR")
+
+        :param indicator: The indicator whose historical records are to be exported
+        :return: This method returns no values
+        """
+        whois = IndicatorRecord.objects.historical_whois(indicator)
+        self._write_records("WR", indicator, whois)
 
     def export_historical(self, indicator, request):
+        """
+        Export all data from the "Historical Activity" tab to CSV.
 
-        hosts = IndicatorRecord.objects.historical_hosts(indicator, request)
-        whois = IndicatorRecord.objects.historical_whois(indicator)
-
-        if hosts:
-            print(hosts)
-            self.line_separator()
-            self.writer.writerow(["Date", "Source", "IP", "Domain", "IP Location"])
-
-            for host in hosts:
-                entry = [host.info_date, host.info_source,
-                         host.info['ip'], host.info['domain'], host.info['geo_location']]
-
-                self.writer.writerow(entry)
-
-        if whois:
-            self.line_separator()
-            self.writer.writerow(['First Seen / Last Seen', 'WHOIS Information'])
-
-            for record in whois:
-                self.writer.writerow([str(record['earliest']) + " / " + str(record['latest']), record['info']])
+        :param indicator: The indicator whose historical activity is to be exported
+        :param request: The request being processed
+        :return: This method returns no values
+        """
+        self.export_historical_hosts(indicator, request)
+        self.line_separator()
+        self.export_historical_whois(indicator)
 
     def export_malware(self, indicator):
+        """
+        Export all Malware Records (IndicatorRecords with a record type of "MR") for an indicator to CSV.
 
+        :param indicator: The indicator whose malware records are to be exported
+        :return: This method returns no values
+        """
         malware = IndicatorRecord.objects.malware_records(indicator)
-
-        if malware:
-            self.line_separator()
-            self.writer.writerow(["Date", "Source", "Indicator", "MD5", "SHA1", "SHA256", "Report Link"])
-
-            for record in malware:
-                entry = [record.info_date, record.info_source, record.info['indicator'], record.info['md5'],
-                         record.info['sha1'], record.info['sha256'], record.info['link']]
-
-                self.writer.writerow(entry)
+        self._write_records("MR", indicator, malware)
 
     def export_search_records(self, indicator):
         """
-        Export Search Results.
+        Export IndicatorRecords with a record type of 'SR' (Search Record).
 
         This will produce a CSV file containing three columns:
             title: The title of the search result
@@ -298,23 +367,59 @@ class ExportRecords(LoginRequiredMixin, View):
         :return: This method does not return any values
         """
         records = IndicatorRecord.objects.get_search_records(indicator)
-        LOGGER.debug("Found %d record(s) for export", len(records))
-        if records:
-            self.line_separator()
-            self.writer.writerow(["Title", "URL", "Content"])
-            number = 0
-            for record in records:
-                number += 1
-                info = record['info']
-                results = info['results']
-                LOGGER.debug("Found %d result(s) in record #%d", len(results), number)
-                for result in results:
-                    LOGGER.debug("Processing result: %s", result)
-                    url = result[core.google.SearchResult.URL]
-                    title = result[core.google.SearchResult.TITLE]
-                    content = result[core.google.SearchResult.CONTENT]
-                    entry = [title, url, content]
-                    self.writer.writerow(entry)
+        self._write_records("SR", indicator, records)
+
+    def _write_records(self, record_type, indicator, records):
+        """
+        Write a list of records of a given type.
+
+        :param record_type: The record type (which should be one of the values from IndicatoRecord.record_choices)
+        :param indicator: The indicator value
+        :param records: The records to be written
+        :return: This method returns no values
+        """
+        record_writer = self._get_csv_writer(record_type)
+        LOGGER.debug("Writing %d record(s) of type '%s' for indicator '%s' using writer type %s",
+                     len(records),
+                     record_type,
+                     indicator,
+                     type(record_writer).__name__)
+        if records is None or 0 == len(records):
+            LOGGER.warn("No '%s' records to write for indicator '%s'", record_type, indicator)
+        else:
+            record_writer.write(indicator, records)
+
+    def _get_csv_writer(self, record_type):
+        """
+        Get a CsvWriter for the given record type
+
+        :param record_type: The record type.  This should match one of the values defined in
+        IndicatorRecord.record_choices.
+        :return: An instantiated CsvWriter
+        """
+        if "SR" == record_type:
+            return SearchCsvWriter(self.writer)
+        elif "HR" == record_type:
+            return HostCsvWriter(self.writer)
+        elif "WR" == record_type:
+            return WhoIsCsvWriter(self.writer)
+        elif "TR" == record_type:
+            return ThreatCrowdCsvWriter(self.writer)
+        elif "CE" == record_type:
+            return CensysCsvWriter(self.writer)
+        elif "SB" == record_type:
+            return SafeBrowsingCsvWriter(self.writer)
+        elif "MR" == record_type:
+            return MalwareCsvWriter(self.writer)
+        else:
+            msg = "No writer for record type: " + record_type
+            LOGGER.error(msg)
+            raise RuntimeError(msg)
 
     def line_separator(self):
+        """
+        Add a blank line in the CSV output.
+
+        :return: This method does not return any values
+        """
         self.writer.writerow([])

--- a/pivoteer/writer/__init__.py
+++ b/pivoteer/writer/__init__.py
@@ -1,0 +1,14 @@
+"""
+A package containing modules used for writing IndicatorRecord data
+
+The base classes and functions are defined in the "core" submodule.  Other submodules contain classes and functions that
+are specific to individual record types.
+"""
+__all__ = ["censys",
+           "core",
+           "hosts",
+           "malware",
+           "safebrowsing",
+           "search",
+           "threatcrowd",
+           "whois"]

--- a/pivoteer/writer/censys.py
+++ b/pivoteer/writer/censys.py
@@ -1,0 +1,38 @@
+"""
+Classes and functions for writing IndicatorRecord objects with a record type of "CE" (Censys Record)
+"""
+
+from pivoteer.writer.core import CsvWriter
+
+
+class CensysCsvWriter(CsvWriter):
+    """
+    A CsvWriter implementation for IndicatorRecords with a record type of "CE" (Censys Record)
+    """
+
+    def __init__(self, writer):
+        """
+        Create a new CsvWriter for Censys Records using the given writer.
+
+        :param writer: The writer
+        """
+        super(CensysCsvWriter, self).__init__(writer)
+
+    def create_title_rows(self, indicator, records):
+        yield ["Certificate Search Results"]
+
+    def create_header(self):
+        return ["Subject", "Issuer", "SHA256", "Validity Start", "Validity End"]
+
+    def create_rows(self, record):
+        info = record["info"]
+        records = info["records"]
+        for record in records:
+            parsed = record["parsed"]
+            subject = parsed["subject_dn"]
+            issuer = parsed["issuer_dn"]
+            sha256 = parsed["fingerprint_sha256"]
+            validity = parsed["validity"]
+            start = validity["start"]
+            end = validity["end"]
+            yield [subject, issuer, sha256, start, end]

--- a/pivoteer/writer/core.py
+++ b/pivoteer/writer/core.py
@@ -1,0 +1,130 @@
+"""
+Classes for writing Pivoteer indicator records to various formats.
+"""
+
+import abc
+
+
+class Writer(object):
+    """
+    A base class for IndicatorRecord writers.
+
+    Writers should NOT be considered thread-safe unless specifically documented as such.
+    """
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def write(self, indicator, record):
+        """
+        Write an IndicatorRecord.
+
+        :param indicator: The indicator value of the record being written
+        :param record: The record to be written
+        :return:
+        """
+        raise NotImplementedError("Writer subclasses must implement 'write'")
+
+
+class CsvWriter(Writer):
+    """
+    An abstract Writer implementation for saving IndicatorRecords in CSV format.
+
+    Subclasses must implement the following methods:
+        create_header: Create a single row (list) that is used as the header for the CSV columns
+        create_rows: Create a list of rows for a record.   You may either return a list or implement this as a generator
+        (though the latter is recommended)
+
+    Subclasses MAY also elect to implement the following method(s):
+        create_title_rows: Create a list of rows to be written at the top of the CSV output providing titular and/or
+        summary information
+
+    Finally, subclasses must remember to properly call the constructor in order to pass a csv.writer object.  Here is an
+    example constructor for the class 'MyClass' which extends CsvWriter:
+        class MyClass(CsvWriter):
+            def __init__(self, writer):
+                super(CsvWriter, self).__init__(writer)
+    """
+
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, writer):
+        """
+        Create a new CSV writer.
+
+        :param writer: The CSV writer object
+        """
+        self.writer = writer
+
+    def create_title_rows(self, indicator, records):
+        """
+        Create any title rows to be included with the CSV output.
+
+        Title rows are placed before the actual header row.  Title rows may contain summary information and are
+        particularly important when combining multiple record types in the same output.
+
+        The default implementation returns an empty list (i.e. no title rows).  Should you choose to override this
+        behavior, you should return a list of lists.   Each inner list is a title row, and each item in that inner list
+        is a column in the row.
+
+        :param indicator: The indicator value
+        :param records: The records being written
+        :return: A list of lists where each inner list is a title row whose items represent columns in that row
+        """
+        return list()
+
+    @abc.abstractmethod
+    def create_header(self):
+        """
+        Create the single header row for CSV output of this record type.
+
+        :return: A list where each item therein is a column header
+        """
+        raise NotImplementedError("CsvWriter subclasses must implement 'create_headers'")
+
+    @abc.abstractmethod
+    def create_rows(self, record):
+        """
+        Convert an IndicatorRecord into row data.
+
+        Some IndicatorRecords actually contain multiple results.  That's why this method expects a iterable of lists.
+        Subclasses may elect to use a generator rather than returning a list, in which case each call should yield a
+        list corresponding to a single row.  If returning a list, each item in the list must in turn be a list
+        representing a single row.
+
+        In other words, you could choose either of these approaches:
+            def create_rows(self, record):
+                # Generator Approach (Recommended)
+                iterable = get_something_from_record(record)
+                for thing in iterable:
+                    row = make_row_from_thing(thing)
+                    yield row
+            def create_rows(self, record):
+                # List Approach
+                iterable = get_something_from_record(record)
+                rows = list()
+                for thing in iterable:
+                    row = make_row_from_thing(thing)
+                    rows.append(row)
+                return rows
+
+        Note that, even if a record corresponds to only one row, it is still necessary to return an iterable.
+
+        :param record: The IndicatorRecord being processed
+        :return: An iterable of row data
+        """
+        raise NotImplementedError("CsvWriter subclasses must implement 'create_row'")
+
+    def write(self, indicator, records):
+        if not records:
+            return
+        titles = self.create_title_rows(indicator, records)
+        for row in titles:
+            self.writer.writerow(row)
+        header_row = self.create_header()
+        if header_row:
+            self.writer.writerow(header_row)
+        for record in records:
+            rows = self.create_rows(record)
+            for row in rows:
+                if row is not None:
+                    self.writer.writerow(row)

--- a/pivoteer/writer/hosts.py
+++ b/pivoteer/writer/hosts.py
@@ -1,0 +1,33 @@
+"""
+Classes and functions for writing Host Records.
+
+Host Records are IndicatorRecords with a record type of "HR."
+"""
+
+from pivoteer.writer.core import CsvWriter
+
+
+class HostCsvWriter(CsvWriter):
+    """
+    A CsvWriter implementation for IndicatorRecord objects with a record type of "HR" (Host Record)
+    """
+
+    def __init__(self, writer):
+        """
+        Create a new CsvWriter for Host Records using the given writer.
+
+        :param writer: The writer
+        """
+        super(HostCsvWriter, self).__init__(writer)
+
+    def create_header(self):
+        return ["Date", "Source", "IP", "Domain", "IP Location"]
+
+    def create_rows(self, record):
+        if record is not None:
+            yield [record.info_date,
+                   record.info_source,
+                   record.info["ip"],
+                   record.info["domain"],
+                   record.info["geo_location"]]
+

--- a/pivoteer/writer/malware.py
+++ b/pivoteer/writer/malware.py
@@ -1,0 +1,31 @@
+"""
+Classes and functions for writing IndicatorRecord objects with record type "MR" (Malware Record)
+"""
+
+from pivoteer.writer.core import CsvWriter
+
+
+class MalwareCsvWriter(CsvWriter):
+    """
+    A CsvWriter implementation for writing Malware Records in CSV format.
+    """
+
+    def __init__(self, writer):
+        """
+        Create a new CsvWriter for Search Records using the given writer
+        :param writer:
+        """
+        super(MalwareCsvWriter, self).__init__(writer)
+
+    def create_header(self):
+        return ["Date", "Source", "Indicator", "MD5", "SHA1", "SHA256", "Report Link"]
+
+    def create_rows(self, record):
+        date = record.info_date
+        source = record.info_source
+        indicator = record.info['indicator']
+        md5 = record.info['md5']
+        sha1 = record.info['sha1']
+        sha256 = record.info['sha256']
+        link = record.info['link']
+        yield [date, source, indicator, md5, sha1, sha256, link]

--- a/pivoteer/writer/safebrowsing.py
+++ b/pivoteer/writer/safebrowsing.py
@@ -1,0 +1,35 @@
+"""
+Classes and functions for writing SafeBrowsing Records, which are IndicatorRecords with a record type of "SB."
+"""
+from django.conf import settings
+from pivoteer.writer.core import CsvWriter
+
+
+class SafeBrowsingCsvWriter(CsvWriter):
+    """
+    A CsvWriter implementation for SafeBrowsing Records
+    """
+
+    def __init__(self, writer):
+        """
+        Create a new CsvWriter for Search Records using the given writer
+        :param writer:
+        """
+        super(SafeBrowsingCsvWriter, self).__init__(writer)
+        self.__link = None
+
+    def write(self, indicator, records):
+        # Note: Currently, the SafeBrowsing CSV format includes the permalink in every row.  This link is based upon the
+        # indicator being processed, which is passed in during this method.  We therefore create and store the permalink
+        # as an instance member for the duration of the 'write' call--thus making this class very not thread safe!
+        self.__link = settings.GOOGLE_SAFEBROWSING_URL + indicator
+        super(SafeBrowsingCsvWriter, self).write(indicator, records)
+        self.__link = None
+
+    def create_header(self):
+        return ["Date", "Response", "SafeBrowsing Link"]
+
+    def create_rows(self, record):
+        date = record.info_date
+        body = record.info["body"]
+        yield [date, body, self.__link]

--- a/pivoteer/writer/search.py
+++ b/pivoteer/writer/search.py
@@ -1,0 +1,37 @@
+"""
+Classes and functions for writing Search Records.
+
+A Search Record is an IndicatorRecord with a record type of "SR."
+"""
+from core.google import SearchResult
+from pivoteer.writer.core import CsvWriter
+
+
+class SearchCsvWriter(CsvWriter):
+    """
+    A CsvWriter for IndicatorRecord objects with a record type of "SR" (Search Record)
+    """
+
+    def __init__(self, writer):
+        """
+        Create a new CsvWriter for Search Records using the given writer
+        :param writer:
+        """
+        super(SearchCsvWriter, self).__init__(writer)
+
+    def create_title_rows(self, indicator, records):
+        title = "Top Google Search Results for Indicator '%s'" % indicator
+        return [[title]]
+
+    def create_header(self):
+        return ["Title", "URL", "Content"]
+
+    def create_rows(self, record):
+        info = record["info"]
+        results = info["results"]
+        for result in results:
+            search_result = SearchResult.from_dict(result)
+            row = [search_result.title,
+                   search_result.url,
+                   search_result.content]
+            yield row

--- a/pivoteer/writer/threatcrowd.py
+++ b/pivoteer/writer/threatcrowd.py
@@ -1,0 +1,54 @@
+"""
+Classes and functions for writing Threat Crowd records.
+
+Threat Crowd Records are IndicatorRecords with a record type of "TR."
+"""
+
+from pivoteer.writer.core import CsvWriter
+
+
+class ThreatCrowdCsvWriter(CsvWriter):
+    """
+    A CsvWriter implementation for writing Threat Crowd Records (i.e. IndicatorRecords with a record type of "TR").
+    """
+
+    def __init__(self, writer):
+        """
+        Create a new CsvWriter for Host Records using the given writer.
+
+        :param writer: The writer
+        """
+        super(ThreatCrowdCsvWriter, self).__init__(writer)
+
+    def create_title_rows(self, indicator, records):
+        return [["ThreatCrowd Records"]]
+
+    def create_header(self):
+        return ["Type", "Data", "Date"]
+
+    def create_rows(self, record):
+        if record is None:
+            return
+        info = record["info"]
+        if info is None:
+            return
+
+        yield ["Lookup Date", record["info_date"], None]
+        info = record["info"]
+        yield ["Permalink", info["permalink"], None]
+        emails = info["emails"]
+        yield ["Emails", ", ".join(emails), None]
+        resolutions = info["resolutions"]
+        if resolutions:
+            for resolution in resolutions:
+                ip = resolution["ip_address"]
+                resolved = resolution["last_resolved"]
+                yield ["Resolution", ip, resolved]
+        subdomains = info["subdomains"]
+        if subdomains:
+            for subdomain in subdomains:
+                yield ["Subdomain", subdomain, None]
+        hashes = info["hashes"]
+        if hashes:
+            for h in hashes:
+                yield ["Hash", h, None]

--- a/pivoteer/writer/whois.py
+++ b/pivoteer/writer/whois.py
@@ -1,0 +1,27 @@
+"""
+Classes and functions for writing IndicatorRecords with a record_type of "WR" (WhoIs Record)
+"""
+
+from pivoteer.writer.core import CsvWriter
+
+
+class WhoIsCsvWriter(CsvWriter):
+    """
+    A CsvWriter implementation for writing IndicatorRecords with a record type of "WR" (WhoIs Record) in CSV format
+    """
+
+    def __init__(self, writer):
+        """
+        Create a new CsvWriter for Search Records using the given writer
+        :param writer:
+        """
+        super(WhoIsCsvWriter, self).__init__(writer)
+
+    def create_header(self):
+        return ["Lookup Date", "WHOIS Information"]
+
+    def create_rows(self, record):
+        if record is not None:
+            date = record["info_date"]
+            info = record["info"]
+            yield [date, info]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ django-braces==1.4.0
 django-widget-tweaks==1.3
 django-pgjson
 dnspython3==1.12.0
+enum34==1.1.3
 geoip2==2.0.2
 html5lib==0.999
 ipwhois==0.9.1


### PR DESCRIPTION
The main thing in this merge request is a reworking of the export code.   I've created a new object hierarchy.   `Writer` is an abstract class that defines a `write` method.  `CsvWriter` is an abstract subclass of Writer that implements `write`.  Subclasses of `CsvWriter` (each of which handles only one record type) must implement two methods:
- `create_header`: Returns a single list where each item is a column header for records
- `create_rows`: Returns an iterable (I recommend using a generator) containing lists where each list is a row and each item in that list is the data for a column in that row

`CsvWriter` subclasses may optionally implement `create_title_rows` which, like `create_rows`, returns an iterable of lists.  The default implementation of `create_title_rows` returns an empty list.

`Writer`, `CsvWriter`, and concrete subclasses for each current record type are available under the `pivoteer.writer` package.

I've also reworked `pivoteer.views.ExportRecords` to use `Writers` to perform export.  Here are the 
instructions for adding new export functionality:
1. Create a pivoteer.writer.core.CsvWriter subclass that processes your record type.
2. Update ExportRecords._get_csv_writer to return an instance of the writer you created in Step 1.
3. Add a new method to ExportRecords that performs two steps:
  1. Retrieve IndicatorRecords (via a method on pivoteer/models/IndicatorManager)
  2. Call self._write_records with your record type, the indicator value, and the records obtained in Step A.  *(Note: If Step A returns a single record, you must wrap it in a list for Step B.)*
4. Update ExportRecords.get to call the method you created in Step 3.